### PR TITLE
ci: use rust 1-70 and bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/rust:1.61-slim-bullseye AS builder
+FROM docker.io/rust:1.70-slim-bookworm AS builder
 RUN apt-get update && \
   apt-get install -y pkg-config libssl-dev && \
   rm -rf /var/lib/apt/lists/*
@@ -6,7 +6,7 @@ WORKDIR /usr/src/app
 COPY . .
 RUN cargo build --release
 
-FROM docker.io/debian:bullseye-slim
+FROM docker.io/debian:bookworm-slim
 WORKDIR /usr/src/app
 COPY --from=builder /usr/src/app/target/release/rapiddb ./
 CMD /usr/src/app/rapiddb


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Changes the Dockerfile to build using Rust 1.70 and Debian bookworm.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have tested, formatted and linted my changes
